### PR TITLE
为批量出售按照动态价格正确计算总价

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "top.mrxiaom.sweet.adaptiveshop"
-version = "1.1.0"
+version = "1.1.1"
 val targetJavaVersion = 8
 val shadowGroup = "top.mrxiaom.sweet.adaptiveshop.libs"
 val pluginBaseVersion = "1.6.5"


### PR DESCRIPTION
在实际使用过程中，发现玩家倾向于囤积大量高价值物品并一次性全部出售，以此规避动态价格带来的影响——导致现在服务器低价值商品很少有玩家出售，因此我为商品批量出售引入了动态价格的影响，以达到正确计算总价的目的。

以下为服务器实测截图。修改前下界之星一次性全部出售可以获得298*40=11920金币，修改后按照动态价格曲线正确计算，总价变为2411金币
![5c8f96f065302206008758bc674e89b7](https://github.com/user-attachments/assets/c536ead6-c917-4233-a5c9-8c9eaee63f9f)
![c4b0807212c0329252843a582ffd30c4_720](https://github.com/user-attachments/assets/d2a1bafe-345a-44a9-94c9-d70479089f80)